### PR TITLE
Fix bug in mean for aggregated distributions

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -143,7 +143,7 @@ list(
   # ) ,
   tar_target(
     dl_gd_means,  purrr::map(cache_inventory$survey_id, function(x) {
-      x <- gdm[survey_id == x][['survey_mean_lcu']]
+      x <- dl_aux$gdm[survey_id == x][['survey_mean_lcu']]
       x <- x * (12/365) # Convert to daily values (PCN is in monthly)
       return(x) 
     })


### PR DESCRIPTION
Hey @randrescastaneda 

We discovered an error in the means for aggregated distributions.  Turns out that for these surveys the urban mean is incorrectly assigned to both the urban and rural distributions. This is because the merging of GD means with `cache_inventory` incorrectly filters only the latest value for duplicated survey ids in `dl_aux@gdm` . 

Instead the `gd_means` object should be a list which contains `NULL` for microdata surveys, a value of length 1 for national grouped data surveys, and a vector of length two for aggregated surveys. 

The change included here reverts to the original code in the TMP-pipeline. This has the added effect of removing the branching for this specific object. I think that is a benefit. But let me know if you think otherwise. 

Also; I did not run the pipeline, since it takes a long time, and I didn't want to mess with the outputs without consulting you. Great if you could review the PR, and run the pipeline at your convenience. (In case you have other changes you can add them up in the same run). 

Code below to illustrate the issue: 

```r 

gdm <- pipaux::load_aux("gdm")
tar_load("cache_inventory")

# This is incorrect 
x <- cache_inventory[gdm,
                on = "survey_id",
                # Convert to daily values (PCN is in monthly) 
                survey_mean_lcu := i.survey_mean_lcu * (12/365) 
]
x[cache_id == "IND_1987_NSS-SCH1_D2_CON_GROUP"]$survey_mean_lcu
[1] 8.216548

# This is correct 
dl_gd_means <- purrr::map(cache_inventory$survey_id, function(x) {
  x <- gdm[survey_id == x][['survey_mean_lcu']]
  x <- x * (12/365) # Convert to daily values (PCN is in monthly)
  return(x) 
})
dl_gd_means[871]
[[1]]
[1] 5.197808 8.216548
```

cc: @tonyfujs 