### PR TITLE
Add data timestamp file

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -527,6 +527,14 @@ list(
                      name     = "interpolated_means", 
                      time     = gls$TIME, 
                      compress = gls$FST_COMP_LVL)
+  ),
+  
+  ### Save data timestamp file ----
+  
+  tar_target(
+    data_timestamp_file,
+    format = 'file', 
+    writeLines(as.character(Sys.time()), paste0(gls$PIP_PIPE_DIR, "pc_data/data_update_timestamp.txt"))
   )
   
 )


### PR DESCRIPTION
Hi @randrescastaneda, @tonyfujs 

We should have a data timestamp file that will feed the (internal) /data-timestamp endpoint in the API. This will make it easier to verify that data updates on Azure work correctly. 

Closes #52. 